### PR TITLE
WSCL Issue: BOOLEAN-DEFINITION

### DIFF
--- a/wscl-issues/draft/boolean-definition
+++ b/wscl-issues/draft/boolean-definition
@@ -30,7 +30,7 @@ Proposal: (BOOLEAN-DEFINITION:TYPE-BOOLEAN-IS-T-OR-NIL)
 Test Cases:
 
   N/A (Test cases are difficult to provide, because conforming implementations
-  are not expected to expose its definition of the type BOOLEAN
+  are not expected to expose their definitions of the type BOOLEAN
   programmatically.)
 
 Rationale:

--- a/wscl-issues/draft/boolean-definition
+++ b/wscl-issues/draft/boolean-definition
@@ -1,0 +1,68 @@
+Issue:          BOOLEAN-DEFINITION
+Forum:          Cleanup
+Category:       CLARIFICATION
+Status:         draft
+Edit History:   16-May-24, Version 1 by Jin-Cheng Guu
+References:     BOOLEAN
+
+Problem Description:
+
+  In the draft ANSI Common Lisp specification, the description of the type
+  BOOLEAN [a] can be more accurate.
+
+    [a]: The type boolean contains the symbols t and nil, [..]
+
+  It is more accurate to use the word "consists of" than "contains". After
+  all, according to the glossary [b], BOOLEAN is exclusively either the symbol
+  T or the symbol NIL.
+
+    [b]: boolean n. an object of type boolean; that is, one of the following
+    objects: the symbol t (representing true), or the symbol nil (representing
+    false).
+
+Proposal:
+
+  This proposal changes the description of the type BOOLEAN so that [a]
+  instead reads:
+
+    > The type boolean consists of the symbols t and nil, [..]
+
+Test Cases:
+
+  N/A (Test cases are difficult to provide, because conforming implementations
+  are not expected to expose its definition of the type BOOLEAN
+  programmatically.)
+
+Rationale:
+
+  This is an improvement for clarity in dpANS.
+
+Current Practice:
+
+  SBCL 2.4.1
+    (slot-value (sb-kernel::specifier-type 'boolean) 'sb-kernel::xset)
+      ;; => #S(SB-INT:XSET :DATA (NIL T) :EXTRA 2)
+
+Cost to Implementors:
+
+  None.
+
+Cost to Users:
+
+  None.
+
+Cost of non-adoption:
+
+  None.
+
+Benefits:
+
+  It makes the standard more accurate.
+
+Aesthetics:
+
+  No influence.
+
+Discussion:
+
+  None.

--- a/wscl-issues/draft/boolean-definition
+++ b/wscl-issues/draft/boolean-definition
@@ -29,9 +29,12 @@ Proposal: (BOOLEAN-DEFINITION:TYPE-BOOLEAN-IS-T-OR-NIL)
 
 Test Cases:
 
-  N/A (Test cases are difficult to provide, because conforming implementations
-  are not expected to expose their definitions of the type BOOLEAN
-  programmatically.)
+  (defun one ()
+    (assert
+     (equal '(t t)
+            (multiple-value-list (subtypep 'boolean '(member t nil))))))
+
+  (one) => NIL
 
 Rationale:
 
@@ -40,8 +43,10 @@ Rationale:
 Current Practice:
 
   SBCL 2.4.1
-    (slot-value (sb-kernel::specifier-type 'boolean) 'sb-kernel::xset)
-      ;; => #S(SB-INT:XSET :DATA (NIL T) :EXTRA 2)
+    (one) ;; => NIL
+
+  ECL 23.9.9
+    (one) ;; => NIL
 
 Cost to Implementors:
 

--- a/wscl-issues/draft/boolean-definition
+++ b/wscl-issues/draft/boolean-definition
@@ -29,10 +29,13 @@ Proposal: (BOOLEAN-DEFINITION:TYPE-BOOLEAN-IS-T-OR-NIL)
 
 Test Cases:
 
-  (defun one ()
+(defun one ()
     (assert
-     (equal '(t t)
-            (multiple-value-list (subtypep 'boolean '(member t nil))))))
+     (and
+      (equal '(t t)
+             (multiple-value-list (subtypep 'boolean '(member t nil))))
+      (equal '(t t)
+             (multiple-value-list (subtypep '(member t nil) 'boolean))))))
 
   (one) => NIL
 

--- a/wscl-issues/draft/boolean-definition
+++ b/wscl-issues/draft/boolean-definition
@@ -20,7 +20,7 @@ Problem Description:
     objects: the symbol t (representing true), or the symbol nil (representing
     false).
 
-Proposal:
+Proposal: (BOOLEAN-DEFINITION:TYPE-BOOLEAN-IS-T-OR-NIL)
 
   This proposal changes the description of the type BOOLEAN so that [a]
   instead reads:

--- a/wscl-issues/draft/boolean-definition
+++ b/wscl-issues/draft/boolean-definition
@@ -37,7 +37,7 @@ Test Cases:
       (equal '(t t)
              (multiple-value-list (subtypep '(member t nil) 'boolean))))))
 
-  (one) => NIL
+  (one) ; => NIL
 
 Rationale:
 
@@ -46,10 +46,10 @@ Rationale:
 Current Practice:
 
   SBCL 2.4.1
-    (one) ;; => NIL
+    (one) ; => NIL
 
   ECL 23.9.9
-    (one) ;; => NIL
+    (one) ; => NIL
 
 Cost to Implementors:
 


### PR DESCRIPTION
In the draft ANSI Common Lisp specification, the description of the type BOOLEAN can be more accurate by changing the term **"contains"** to the term **"consists of"**.